### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,7 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 
 gem 'pry-rails'
+
+gem 'payjp'
+
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -161,6 +162,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
@@ -298,6 +304,7 @@ DEPENDENCIES
   mini_magick
   mysql2 (~> 0.5)
   pg
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   rspec-rails (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -110,6 +112,14 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -137,10 +147,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.6)
       date
@@ -151,6 +165,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
@@ -161,6 +176,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -207,9 +224,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -266,6 +290,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -298,11 +325,13 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -205,3 +205,8 @@
   font-weight: bold;
   font-size: 23px;
 }
+
+.sold-out-item{
+  color:red;
+  font-size:30px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,8 @@ class ItemsController < ApplicationController
 
   def edit
     # ログインしているユーザーであればeditファイルが読み込み
-    if @item.user_id == current_user.id
+    # itemが購入されているか判定を行う(@item.order.nil?でorderがない場合のみeditファイルを読み込む)
+    if @item.user_id == current_user.id && @item.order.nil?
     else
       redirect_to root_path
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -22,7 +22,9 @@ class OrdersController < ApplicationController
 
   private
   def set_item
+    #対象の商品を探し、購入済みか否かの判断を事前にberore_actionにて行う
     @item = Item.find(params[:item_id])
+    redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
   end
 
   def pay_item

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,12 +3,16 @@ class OrdersController < ApplicationController
   before_action :set_item, only: [:index, :create]
 
   def index
+    #JavaScriptで変数が使用できるよう設定
+    #公開鍵を環境変数に設定
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
     @order_payment = OrderPayment.new
   end
 
   def create
     @order_payment = OrderPayment.new(order_params)
     if @order_payment.valid?
+      pay_item
       @order_payment.save
       redirect_to root_path
     else
@@ -21,8 +25,18 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
+  def pay_item
+    #秘密鍵を環境変数に設定
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp::Charge.create(
+      amount: @item.price,        # 商品の値段
+      card: order_params[:token], # カードトークン
+      currency: 'jpy'             # 通貨(日本円）
+    )
+  end
+
   def order_params
-    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id],token: params[:token])
   end
 
   

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,6 @@
+class OrdersController < ApplicationController
+
+  def index
+    @order_payment = OrderPayment.new(order_params)
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,29 @@
 class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_item, only: [:index, :create]
 
   def index
-    @order_payment = OrderPayment.new(order_params)
+    @order_payment = OrderPayment.new
   end
+
+  def create
+    @order_payment = OrderPayment.new(order_params)
+    if @order_payment.valid?
+      @order_payment.save
+      redirect_to root_path
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  def order_params
+    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+
+  
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const publickey = gon.public_key
+  const payjp = Payjp(publickey)// PAY.JPテスト公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,31 @@
+const pay = () => {
+  const payjp = Payjp('pk_live_19918d8a6a7d7e0949313b02')// PAY.JP公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,17 +10,18 @@ class Item < ApplicationRecord
   belongs_to :shipping_cost
   belongs_to :shipping_date
 
-  validates :image, presence: true
-  validates :name, presence: true
-  validates :description, presence: true
-  validates :category_id, presence: true
-  validates :item_status_id, presence: true
-  validates :shipping_cost_id, presence: true
-  validates :prefecture_id, presence: true
-  validates :shipping_date_id, presence: true
-  # 300円以上かつ9,999,999円以下で、半角数字でないと入力不可
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, only_integer: true }
-
+  with_options presence: true do
+    validates :image, presence: true
+    validates :name, presence: true
+    validates :description, presence: true
+    validates :category_id, presence: true
+    validates :item_status_id, presence: true
+    validates :shipping_cost_id, presence: true
+    validates :prefecture_id, presence: true
+    validates :shipping_date_id, presence: true
+    # 300円以上かつ9,999,999円以下で、半角数字でないと入力不可
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, only_integer: true }
+  end
    
   # 選択が「--」の時(0の時)は保存不可のバリデーション
   validates :category_id,numericality: { other_than: 0 , message: "カテゴリーを選択してください" }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
+
+  has_one    :order
   belongs_to :user
   has_one_attached :image
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :payment
+end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -17,7 +17,7 @@ class OrderPayment
     #tokenのバリデーション(本来テーブルに存在しない為バリデーションは出来ないが、attr_accessor :tokenによりバリデーション可能)
     validates :token
    #先頭が0以外(国際電話)に対応かつ9桁以上11桁以下の電話番号を許可
-    validates :phone_number, format: {  with: /\A[0-9]{11}\z/, message: 'is invalid' }
+    validates :phone_number, format: {  with: /\A[0-9]{10,11}\z/, message: 'is invalid' }
     
   end
   

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -13,7 +13,9 @@ class OrderPayment
     validates :city
     validates :block
     #validates :building 任意のデータはバリデーション不要
-    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid' }
+
+    #先頭に０、後に1から９までの１０桁の数字のバリデーションを設定
+    validates :phone_number, format: { with: /\A0\d{9,10}\z/, message: 'is invalid' }
     
   end
   

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -13,10 +13,7 @@ class OrderPayment
     valid :city
     valid :block
     valid :bulding
-    validates :phone_number, format: {
-      with: /\A\d{3}-\d{4}-\d{4}\z/,
-      message: "フォーマットが正しくありません。例: 123-4567-8901"
-    }
+    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid' }
     
   end
   

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -17,7 +17,7 @@ class OrderPayment
     #tokenのバリデーション(本来テーブルに存在しない為バリデーションは出来ないが、attr_accessor :tokenによりバリデーション可能)
     validates :token
    #先頭が0以外(国際電話)に対応かつ9桁以上11桁以下の電話番号を許可
-    validates :phone_number, format: { with: /\A0\d{9,10}\z|\A\d{9,11}\z/, message: 'is invalid' }
+    validates :phone_number, format: {  with: /\A[0-9]{11}\z/, message: 'is invalid' }
     
   end
   

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -16,9 +16,8 @@ class OrderPayment
 
     #tokenのバリデーション(本来テーブルに存在しない為バリデーションは出来ないが、attr_accessor :tokenによりバリデーション可能)
     validates :token
-
-    #先頭に０、後に1から９までの１０桁の数字のバリデーションを設定
-    validates :phone_number, format: { with: /\A0\d{9,10}\z/, message: 'is invalid' }
+   #先頭が0以外(国際電話)に対応かつ9桁以上11桁以下の電話番号を許可
+    validates :phone_number, format: { with: /\A0\d{9,10}\z|\A\d{9,11}\z/, message: 'is invalid' }
     
   end
   

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,0 +1,30 @@
+class OrderPayment
+  include ActiveModel::model
+  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :bulding, :phone_number
+
+
+  with_options presence: true do
+    #order バリデーション
+    valid :user_id
+    valid :item_id
+    #payment バリデーション
+    valid :postcode, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    valid :prefecture_id, numericality: {other_than: 0, message: "can't be blank"} 
+    valid :city
+    valid :block
+    valid :bulding
+    validates :phone_number, format: {
+      with: /\A\d{3}-\d{4}-\d{4}\z/,
+      message: "フォーマットが正しくありません。例: 123-4567-8901"
+    }
+    
+  end
+  
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Payment.create(order_id: order.id, postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building, phone_number: phone_number)
+  end
+
+
+
+end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,18 +1,18 @@
 class OrderPayment
-  include ActiveModel::model
-  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :bulding, :phone_number
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
 
 
   with_options presence: true do
     #order バリデーション
-    valid :user_id
-    valid :item_id
+    validates :user_id
+    validates :item_id
     #payment バリデーション
-    valid :postcode, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
-    valid :prefecture_id, numericality: {other_than: 0, message: "can't be blank"} 
-    valid :city
-    valid :block
-    valid :bulding
+    validates :postcode, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    validates :prefecture_id, numericality: {other_than: 0, message: "can't be blank"} 
+    validates :city
+    validates :block
+    #validates :building 任意のデータはバリデーション不要
     validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid' }
     
   end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,6 +1,6 @@
 class OrderPayment
   include ActiveModel::Model
-  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
+  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number, :token
 
 
   with_options presence: true do
@@ -13,6 +13,9 @@ class OrderPayment
     validates :city
     validates :block
     #validates :building 任意のデータはバリデーション不要
+
+    #tokenのバリデーション(本来テーブルに存在しない為バリデーションは出来ないが、attr_accessor :tokenによりバリデーション可能)
+    validates :token
 
     #先頭に０、後に1から９までの１０桁の数字のバリデーションを設定
     validates :phone_number, format: { with: /\A0\d{9,10}\z/, message: 'is invalid' }

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,3 @@
+class Payment < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
           :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
 
   with_options presence: true do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,17 +1,22 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :validatable
+
   has_many :items
 
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
-  validates :nickname, presence: true
-  validates :last_name , presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
-  validates :first_name, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
-  validates :last_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :birthday, presence: true
 
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  with_options presence: true do
+    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+    validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
+    validates :nickname
+    validates :last_name , format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+    validates :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+    validates :birthday
+  end
+
+    
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,7 +8,9 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%# 第一引数にインスタンス変数を渡し、予めフォームに値が入力された状態にする  %>
-    <%= form_with(model: @item, local: true) do |f| %>
+
+    <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
+    <%= form_with(model: @item, local: true, data: { turbo: false }) do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,7 +8,9 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%# 第一引数にインスタンス変数を渡し、予めフォームに値が入力された状態にする  %>
-    <%= form_with(model: @item, local: true) do |f| %>
+
+    <%# rails7.0.0を使用する際は、表示エラーが起こるためdata: { turbo: false }を追加 %>
+    <%= form_with(model: @item, local: true,data: { turbo: false }) do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,11 +135,13 @@
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold out表示 %>
+          <% if item.order != nil %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %>
+
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -183,7 +183,7 @@
   </div>
   <%# /商品一覧 %>
 </div>
-<%# rails7.0.0ではjavascriptとの相性が悪いらしいので、turbo: falseでturboが実行しないよう設定。%>
+<%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
 <%= link_to(new_item_path, data: { turbo: false }, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,12 +27,15 @@
     <% if user_signed_in? %>
     <%# 「商品の編集」「削除」ボタンを表示 %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+      <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get,data: { turbo: false }, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%# 出品者でなく、未購入品の場合: 「購入画面に進む」ボタンを表示 %>
-        <%= link_to "購入画面に進む", item_orders_path(@item), class: "item-red-btn" %>
+        
+        <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
+        <%= link_to "購入画面に進む", item_orders_path(@item),data: { turbo: false }, class: "item-red-btn" %>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,13 @@
     </h2>
     <div class="item-img-content">
        <%= image_tag @item.image.variant(resize: '500x500'), class: "item-box-img"  %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品が売れている場合は、sold out %>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
+      
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -26,15 +28,17 @@
     <%# ユーザーがログインしている場合 %>
     <% if user_signed_in? %>
     <%# 「商品の編集」「削除」ボタンを表示 %>
-      <% if current_user == @item.user %>
+      <% if current_user == @item.user && @item.order.nil? %>
       <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get,data: { turbo: false }, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%# rails7.0.0を使用する際は、表示エラーが起こるためdata: { turbo: false }を追加 %>
         <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
+      <%# 売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない %>
+      <% elsif @item.order.present? %>
+        <%= link_to "売り切れ", item_path(@item), class:"sold-out-item" %>
+      <%# 出品者でなく、未購入品の場合「購入画面に進む」ボタンを表示 %>
       <% else %>
-        <%# 出品者でなく、未購入品の場合: 「購入画面に進む」ボタンを表示 %>
-        
         <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
         <%= link_to "購入画面に進む", item_orders_path(@item),data: { turbo: false }, class: "item-red-btn" %>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,12 +27,14 @@
     <% if user_signed_in? %>
     <%# 「商品の編集」「削除」ボタンを表示 %>
       <% if current_user == @item.user %>
+        
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
+        <%# rails7.0.0を使用する際は、表示エラーが起こるためdata: { turbo: false }を追加 %>
         <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%# 出品者でなく、未購入品の場合: 「購入画面に進む」ボタンを表示 %>
-        <%= link_to "購入画面に進む", item_orders_path(@item), class: "item-red-btn" %>
+        <%= link_to "購入画面に進む", item_orders_path(@item), data: { turbo: false },class: "item-red-btn" %>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,7 @@
         <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%# 出品者でなく、未購入品の場合: 「購入画面に進む」ボタンを表示 %>
-        <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+        <%= link_to "購入画面に進む", item_orders_path(@item), class: "item-red-btn" %>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -12,7 +12,7 @@
       <%= image_tag @item.image.variant(resize: '500x500'), class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
           <%# 商品の金額と配送料負担情報をインスタンス変数で設定 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,16 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%# @item(インスタンス変数)のイメージを表示 %>
+      <%= image_tag @item.image.variant(resize: '500x500'), class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
           <%= "商品名" %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <%# 商品の金額と配送料負担情報をインスタンス変数で設定 %>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_cost.name %></p>
         </div>
       </div>
     </div>
@@ -26,7 +28,8 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        <%# 商品の金額(@item.price)を設定 %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,127 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with model: @order_payment, url: item_orders_path(@item),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="number-form" class="input-default"></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="cvc-form" class="input-default"></div>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :postcode, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all , :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :block, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -34,7 +34,9 @@
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with model: @order_payment, url: item_orders_path(@item),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+    <%# rails7.0.0を使用する際は、表示エラーが起こるためdata: { turbo: false }を追加 %>
+    <%= form_with model: @order_payment, url: item_orders_path(@item),  id: 'charge-form', class: 'transaction-form-wrap',data: { turbo: false },local: true do |f| %>
     
     <%# インスタンスを渡して、エラー発生時にメッセージを表示。%>
     <%= render 'shared/error_messages', model: f.object %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -35,6 +35,10 @@
     <%# /支払額の表示 %>
 
     <%= form_with model: @order_payment, url: item_orders_path(@item),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    
+    <%# インスタンスを渡して、エラー発生時にメッセージを表示。%>
+    <%= render 'shared/error_messages', model: f.object %>
+    
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,3 +1,4 @@
+<%= include_gon %>
 <%= render "shared/second-header"%>
 
 <div class='transaction-contents'>
@@ -34,7 +35,8 @@
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with model: @order_payment, url: item_orders_path(@item),  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# rails7.0.0ではjavascriptとの相性が悪い為、turbo: falseでturboが実行しないよう設定%>
+    <%= form_with model: @order_payment, url: item_orders_path(@item), data: { turbo: false },  id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     
     <%# インスタンスを渡して、エラー発生時にメッセージを表示。%>
     <%= render 'shared/error_messages', model: f.object %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  
+  #rails7を使用するときは、javascriptに表示エラーが出るため追加
+  config.assets.debug = true
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  #rails 7.0.0を使用する時は、表示エラーが発生するので下記を追加
+  config.assets.debug = true
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "item_price", to: "item_price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
 
-  resources :items
+  resources :items do
+    #商品(item)が無いと実行されない為itemsにネスト
+    #index.html.erbと紐付いている為indexを定義
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230818024853_create_orders.rb
+++ b/db/migrate/20230818024853_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table   :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230818025117_create_payments.rb
+++ b/db/migrate/20230818025117_create_payments.rb
@@ -1,0 +1,14 @@
+class CreatePayments < ActiveRecord::Migration[7.0]
+  def change
+    create_table   :payments do |t|
+      t.references :order,         null: false, foreign_key: true
+      t.string     :postcode,      null: false
+      t.integer    :prefecture_id, null: false
+      t.string     :city,          null: false
+      t.string     :block,         null: false
+      t.string     :building
+      t.string     :phone_number,  null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_04_221443) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_18_025117) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_04_221443) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "payments", charset: "utf8", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.string "postcode", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "block", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_payments_on_order_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -75,4 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_04_221443) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "payments", "orders"
 end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -7,8 +7,7 @@ FactoryBot.define do
     city { Faker::Address.city }
     block { Faker::Address.street_address }
     building { Faker::Address.secondary_address }
-    #先頭に0を付与、その後0から始まる10桁の半角数値を生成
-    phone_number { "0#{Faker::Number.leading_zero_number(digits: 9)}" }
+    phone_number { Faker::Number.decimal_part(digits: 11) }
     #tokenのテストを追加
     token { Faker::Internet.password(min_length: 20, max_length: 30) }
   end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order_payment do
+    user_id { FactoryBot.create(:user).id }
+    item_id { FactoryBot.create(:item).id }
+    postcode { "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 4)}" }
+    prefecture_id { Faker::Number.between(from: 1, to: 47) }
+    city { Faker::Address.city }
+    block { Faker::Address.street_address }
+    building { Faker::Address.secondary_address }
+    #先頭に0を付与、その後0から始まる10桁の半角数値を生成
+    phone_number { "0#{Faker::Number.leading_zero_number(digits: 9)}" }
+  end
+end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -9,5 +9,7 @@ FactoryBot.define do
     building { Faker::Address.secondary_address }
     #先頭に0を付与、その後0から始まる10桁の半角数値を生成
     phone_number { "0#{Faker::Number.leading_zero_number(digits: 9)}" }
+    #tokenのテストを追加
+    token { Faker::Internet.password(min_length: 20, max_length: 30) }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :payment do
+    
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe OrderPayment, type: :model do
         @order_payment.phone_number = '09012345678'
         expect(@order_payment).to be_valid
       end
+      #tokenのテスト追加
+      it "priceとtokenがあれば保存ができること" do
+        expect(@order_payment).to be_valid
+      end
     end
 
     context '配送先情報の保存ができないとき' do
@@ -100,6 +104,12 @@ RSpec.describe OrderPayment, type: :model do
         @order_payment.phone_number = 11_111_111_111_111_11111
         @order_payment.valid?
         expect(@order_payment.errors.full_messages).to include('Phone number is invalid')
+      end
+      #tokenのテストを追加
+      it "tokenが空では登録できないこと" do
+        @order_payment.token = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Token can't be blank")
       end
       
     end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe OrderPayment, type: :model do
+  before do
+    user = FactoryBot.create(:user)
+    @order_payment = FactoryBot.build(:order_payment, user_id: user.id)
+  end
+
+  describe '配送先情報の保存' do
+    context '配送先情報の保存ができるとき' do
+      it 'すべての値が正しく入力されていれば保存できること' do
+        expect(@order_payment).to be_valid
+      end
+      it 'user_idが空でなければ保存できる' do
+        @order_payment.user_id = 1
+        expect(@order_payment).to be_valid
+      end
+      it 'item_idが空でなければ保存できる' do
+        @order_payment.item_id = 1
+        expect(@order_payment).to be_valid
+      end
+      it '郵便番号が「3桁、ハイフン、4桁」の組み合わせであれば保存できる' do
+        @order_payment.postcode = '111-1111'
+        expect(@order_payment).to be_valid
+      end
+      it '都道府県が「---」以外かつ空でなければ保存できる' do
+        @order_payment.prefecture_id = 1
+        expect(@order_payment).to be_valid
+      end
+      it '市区町村が空でなければ保存できる' do
+        @order_payment.city = '山鹿市'
+        expect(@order_payment).to be_valid
+      end
+      it '番地が空でなければ保存できる' do
+        @order_payment.block = 'やまが区111'
+        expect(@order_payment).to be_valid
+      end
+      it '建物名が空でも保存できる' do
+        @order_payment.building = nil
+        expect(@order_payment).to be_valid
+      end
+      it '電話番号が10桁以上11桁以内の半角数値のみであれば保存できる' do
+        @order_payment.phone_number = '09012345678'
+        expect(@order_payment).to be_valid
+      end
+    end
+
+    context '配送先情報の保存ができないとき' do
+      it 'user_idが空だと保存できない' do
+        @order_payment.user_id = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("User can't be blank")
+      end
+      it 'item_idが空だと保存できない' do
+        @order_payment.item_id = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Item can't be blank")
+      end
+      it '郵便番号が空だと保存できないこと' do
+        @order_payment.postcode = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Postcode can't be blank", 'Postcode is invalid. Include hyphen(-)')
+      end
+      it '郵便番号にハイフンがないと保存できないこと' do
+        @order_payment.postcode = 111111
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include('Postcode is invalid. Include hyphen(-)')
+      end
+      it '都道府県が「---」だと保存できないこと' do
+        @order_payment.prefecture_id = 0
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '都道府県が空だと保存できないこと' do
+        @order_payment.prefecture_id = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '市区町村が空だと保存できないこと' do
+        @order_payment.city = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("City can't be blank")
+      end
+      it '番地が空だと保存できないこと' do
+        @order_payment.block = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Block can't be blank")
+      end
+      it '電話番号が空だと保存できないこと' do
+        @order_payment.phone_number = nil
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it '電話番号にハイフンがあると保存できないこと' do
+        @order_payment.phone_number = '111 - 11111 - 1111'
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号が12桁以上あると保存できないこと' do
+        @order_payment.phone_number = 11_111_111_111_111_11111
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include('Phone number is invalid')
+      end
+      
+    end
+  end
+end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe OrderPayment, type: :model do
         @order_payment.building = nil
         expect(@order_payment).to be_valid
       end
-      it '電話番号が10桁以上11桁以内の半角数値のみであれば保存できる' do
-        @order_payment.phone_number = '09012345678'
+      it '電話番号が11番桁以内、ハイフンなしであれば保存できる' do
+        @order_payment.phone_number = '11111111111'
         expect(@order_payment).to be_valid
       end
       #tokenのテスト追加
@@ -100,8 +100,8 @@ RSpec.describe OrderPayment, type: :model do
         @order_payment.valid?
         expect(@order_payment.errors.full_messages).to include('Phone number is invalid')
       end
-      it '電話番号が12桁以上あると保存できないこと' do
-        @order_payment.phone_number = 11_111_111_111_111_11111
+      it '電話番号が9桁以下では購入できない' do
+        @order_payment.phone_number = 11111111
         @order_payment.valid?
         expect(@order_payment.errors.full_messages).to include('Phone number is invalid')
       end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
#Why
商品購入機能の実装

#What
ユーザーの商品購入機能を実装するため

#必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/771a6b749b975cf1d409c156a83e8d79

#入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/466ddd25a3850f40ddd7b680bdc717b7

# ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/d706e42457b454a2702af1e18004bd22

#ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/336ef15718e65ac64a86f58a1002d4b9

#ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/3a5225f0a82b52d87780da66f51389ff

# 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/6afb5cb43b3b4bfffeba7072f6bd20cf

#売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/013fb0796d5df9d251dae1fc21b25ae3

# ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/ced0ea77f0a0579a3defd6ccd407290a

# ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/4e35495c076d4f560b1f57a411295c3d

# テスト結果の画像
https://gyazo.com/b8be80f5586b7b5141eb05d3fa6858d7